### PR TITLE
feat: add connection tag utils

### DIFF
--- a/packages/connection-tag-utils/package.json
+++ b/packages/connection-tag-utils/package.json
@@ -19,7 +19,7 @@
     "build": "tsc -p tsconfig.build.json",
     "test": "mocha --require ts-node/register/transpile-only --ui mocha-typescript --require source-map-support/register --watch-extensions ts test/*.ts",
     "cover": "nyc --extension .ts --reporter=json --reporter=html --require ts-node/register/transpile-only --ui mocha-typescript --require source-map-support/register mocha test/*.spec.ts",
-    "codecov": "codecov --root=../../ -f coverage/*.json -F connection-tag-utils"
+    "codecov": "codecov --root=../../ -f coverage/*.json -F connection_tag_utils"
   },
   "dependencies": {
     "base64url": "^3.0.1"

--- a/packages/connection-tag-utils/package.json
+++ b/packages/connection-tag-utils/package.json
@@ -20,5 +20,8 @@
     "test": "mocha --require ts-node/register/transpile-only --ui mocha-typescript --require source-map-support/register --watch-extensions ts test/*.ts",
     "cover": "nyc --extension .ts --reporter=json --reporter=html --require ts-node/register/transpile-only --ui mocha-typescript --require source-map-support/register mocha test/*.spec.ts",
     "codecov": "codecov --root=../../ -f coverage/*.json -F connection-tag-utils"
+  },
+  "dependencies": {
+    "base64url": "^3.0.1"
   }
 }

--- a/packages/connection-tag-utils/package.json
+++ b/packages/connection-tag-utils/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "connection-tag-utils",
-  "version": "1.0.0",
+  "name": "@interledger/connection-tag-utils",
+  "version": "0.0.0",
   "author": "Interledger Team <info@interledger.org>",
   "license": "Apache-2.0",
   "description": "Utilities for encrypted STREAM connection tags",

--- a/packages/connection-tag-utils/package.json
+++ b/packages/connection-tag-utils/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "connection-tag-utils",
+  "version": "1.0.0",
+  "author": "Interledger Team <info@interledger.org>",
+  "license": "Apache-2.0",
+  "description": "Utilities for encrypted STREAM connection tags",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist/**/*.js",
+    "dist/**/*.js.map",
+    "dist/**/*.d.ts"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "clean": "rimraf .nyc_output/* dist/* coverage/*",
+    "build": "tsc -p tsconfig.build.json",
+    "test": "mocha --require ts-node/register/transpile-only --ui mocha-typescript --require source-map-support/register --watch-extensions ts test/*.ts",
+    "cover": "nyc --extension .ts --reporter=json --reporter=html --require ts-node/register/transpile-only --ui mocha-typescript --require source-map-support/register mocha test/*.spec.ts",
+    "codecov": "codecov --root=../../ -f coverage/*.json -F connection-tag-utils"
+  }
+}

--- a/packages/connection-tag-utils/src/index.ts
+++ b/packages/connection-tag-utils/src/index.ts
@@ -1,0 +1,39 @@
+import * as crypto from 'crypto'
+import base64url from 'base64url'
+
+export type Key = string | Buffer
+
+export function encode (key: Key, data: string) {
+  const iv = crypto.randomBytes(12)
+  const cipher = crypto.createCipheriv('aes-256-gcm', key, iv)
+  const encrypted = Buffer.concat([
+    cipher.update(data, 'utf8'),
+    cipher.final()
+  ])
+
+  const tag = cipher.getAuthTag()
+  const complete = Buffer.concat([
+    tag,
+    iv,
+    encrypted
+  ])
+
+  return base64url(complete)
+}
+
+export function decode (key: Key, completeEncoded: string) {
+  const complete = Buffer.from(completeEncoded, 'base64')
+  const tag = complete.slice(0, 16)
+  const iv = complete.slice(16, 16 + 12)
+  const encrypted = complete.slice(16 + 12)
+
+  const decipher = crypto.createDecipheriv('aes-256-gcm', key, iv)
+  decipher.setAuthTag(tag)
+
+  const data = Buffer.concat([
+    decipher.update(encrypted),
+    decipher.final()
+  ])
+
+  return data.toString('utf8')
+}

--- a/packages/connection-tag-utils/test/index.spec.ts
+++ b/packages/connection-tag-utils/test/index.spec.ts
@@ -1,0 +1,12 @@
+import * as Tag from '..'
+import { randomBytes } from 'crypto'
+import { expect } from 'chai'
+
+describe('encode & decode', () => {
+  it('should decode an encoded tag', () => {
+    const key = randomBytes(32)
+    const encoded = Tag.encode(key, '{"foo":"bar"}')
+    const decoded = Tag.decode(key, encoded)
+    expect(decoded).equals('{"foo":"bar"}')
+  })
+})

--- a/packages/connection-tag-utils/tsconfig.build.json
+++ b/packages/connection-tag-utils/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "baseUrl": ".",
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "./dist/tsconfig.build.tsbuildbuildinfo"
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1353,6 +1353,11 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
+base64url@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/base64url/-/base64url-3.0.1.tgz#6399d572e2bc3f90a9a8b22d5dbb0a32d33f788d"
+  integrity sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==
+
 base@^0.11.1:
   version "0.11.2"
   resolved "https://registry.yarnpkg.com/base/-/base-0.11.2.tgz#7bde5ced145b6d551a90db87f83c558b4eb48a8f"


### PR DESCRIPTION
Puts utils for encrypted connection tags into its own library. This is useful because it lets you encrypt the contents of your STREAM connection tags, preventing them from being leaked to intermediaries on the ILP network.