### PR TITLE
feat(ildcp): support custom expiresAt for fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Script commands such as `test` and `lint` can be run from the root of the projec
 yarn test
 
 #Scoping to a package
-yarn test --scope=packages/<package-name>
+yarn test --scope=<package-name>
 ```
 
 or in the package directory


### PR DESCRIPTION
This option is useful in the web extension when the client has a badly skewed clock. The extension can set a fixed, distant `expiresAt` for all Prepare packets. The first connector will automatically [replace it with a sensible value](https://github.com/interledgerjs/ilp-connector/blob/ff20aff6f064945ef4b616baaa06990c2592707a/src/services/route-builder.ts#L122) (`now + maxHoldTime`).