### PR TITLE
perf(logger): cleanup loggers

### DIFF
--- a/packages/ilp-logger/package.json
+++ b/packages/ilp-logger/package.json
@@ -22,7 +22,7 @@
     "codecov": "codecov --root=../../ -f coverage/*.json -F ilp_logger"
   },
   "dependencies": {
-    "@types/debug": "^0.0.31",
+    "@types/debug": "^4.1.0",
     "debug": "^4.1.0",
     "supports-color": "^5.5.0"
   }

--- a/packages/ilp-logger/src/index.ts
+++ b/packages/ilp-logger/src/index.ts
@@ -2,11 +2,11 @@ import * as debug from 'debug'
 
 export class Logger {
   private namespace: string
-  public info: debug.IDebugger
-  public warn: debug.IDebugger
-  public error: debug.IDebugger
-  public debug: debug.IDebugger
-  public trace: debug.IDebugger
+  public info: debug.Debugger
+  public warn: debug.Debugger
+  public error: debug.Debugger
+  public debug: debug.Debugger
+  public trace: debug.Debugger
   constructor(namespace: string) {
     this.namespace = namespace
     this.info = debug(namespace + ':info')
@@ -48,7 +48,7 @@ interface ModuleExport {
   (namespace: string): Logger
   default: ModuleExport
   Logger: Function
-  formatters: debug.IFormatters
+  formatters: debug.Formatters
 }
 
 createLogger.default = createLogger

--- a/packages/ilp-logger/src/index.ts
+++ b/packages/ilp-logger/src/index.ts
@@ -14,6 +14,23 @@ export class Logger {
     this.error = debug(namespace + ':error')
     this.debug = debug(namespace + ':debug')
     this.trace = debug(namespace + ':trace')
+    // `debug().destroy()` leaves the logger usable, but allows it to be garbage
+    // collected once references to the `Logger` have been dropped.
+    //
+    // The only change in functionality is that `debug.enable(namespaces)` won't
+    // be able to dynamically change the enabled log levels, but we do not rely on
+    // that functionality.
+    //
+    // Without `destroy()`, creating loggers with dynamically generated namespaces
+    // leaks memory due to the `debug` closures and namespaces strings never being
+    // cleaned up.
+    //
+    // See: https://github.com/visionmedia/debug/blob/80ef62a3af4df95250d77d64edfc3d0e1667e7e8/src/common.js#L134-L141
+    this.info.destroy()
+    this.warn.destroy()
+    this.error.destroy()
+    this.debug.destroy()
+    this.trace.destroy()
   }
 
   extend(namespace: string): Logger {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1522,6 +1522,11 @@
   resolved "https://registry.yarnpkg.com/@types/debug/-/debug-0.0.31.tgz#bac8d8aab6a823e91deb7f79083b2a35fa638f33"
   integrity sha512-LS1MCPaQKqspg7FvexuhmDbWUhE2yIJ+4AgVIyObfc06/UKZ8REgxGNjZc82wPLWmbeOm7S+gSsLgo75TanG4A==
 
+"@types/debug@^4.1.0":
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.5.tgz#b14efa8852b7768d898906613c23f688713e02cd"
+  integrity sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ==
+
 "@types/eslint-visitor-keys@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"


### PR DESCRIPTION
`debug().destroy()` leaves the logger usable, but allows it to be garbage collected once references to the `Logger` have been dropped.

The only change in functionality is that `debug.enable(namespaces)` won't be able to dynamically change the enabled log levels, but we do not rely on that functionality.

Without `destroy()`, creating loggers with dynamically generated namespaces leaks memory due to the `debug` closures and namespaces strings never being cleaned up.

See: https://github.com/visionmedia/debug/blob/80ef62a3af4df95250d77d64edfc3d0e1667e7e8/src/common.js#L134-L141