### PR TITLE
chore(logger): bump debug; fix deprecation warning

### DIFF
--- a/packages/ilp-logger/package.json
+++ b/packages/ilp-logger/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@types/debug": "^4.1.0",
-    "debug": "^4.1.0",
+    "debug": "^4.3.0",
     "supports-color": "^7.1.0"
   }
 }

--- a/packages/ilp-logger/src/index.ts
+++ b/packages/ilp-logger/src/index.ts
@@ -15,24 +15,6 @@ export class Logger {
     this.error = debug(namespace + ':error')
     this.debug = debug(namespace + ':debug')
     this.trace = debug(namespace + ':trace')
-
-    // `debug().destroy()` leaves the logger usable, but allows it to be garbage
-    // collected once references to the `Logger` have been dropped.
-    //
-    // The only change in functionality is that `debug.enable(namespaces)` won't
-    // be able to dynamically change the enabled log levels, but we do not rely on
-    // that functionality.
-    //
-    // Without `destroy()`, creating loggers with dynamically generated namespaces
-    // leaks memory due to the `debug` closures and namespaces strings never being
-    // cleaned up.
-    //
-    // See: https://github.com/visionmedia/debug/blob/80ef62a3af4df95250d77d64edfc3d0e1667e7e8/src/common.js#L134-L141
-    this.info.destroy()
-    this.warn.destroy()
-    this.error.destroy()
-    this.debug.destroy()
-    this.trace.destroy()
   }
 
   extend(namespace: string): Logger {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3486,7 +3486,7 @@ debug@3.1.0, debug@=3.1.0, debug@~3.1.0:
   dependencies:
     ms "2.0.0"
 
-debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.2.0, debug@^4.3.2:
+debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.2.0, debug@^4.3.0, debug@^4.3.2:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b"
   integrity sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==


### PR DESCRIPTION
Pre-`debug@4.3.0`, calling `.destroy()` on `debug` logger instances was necessary to avoid leaking memory when loggers are dynamically created.

Post-`debug@4.3.0`, destroying loggers is unnecessary and deprecated (see: https://github.com/visionmedia/debug/blob/4.3.0/src/common.js#L253).