### PR TITLE
chore(ci): run CI on node v14

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x]
+        node-version: [10.x, 12.x, 14.x]
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
B/c Rafiki depends on many of these packages, and it tests against node.js v14.