### PR TITLE
fix(ilp-packet): test address on decoding prepare

### DIFF
--- a/packages/ilp-packet/src/index.ts
+++ b/packages/ilp-packet/src/index.ts
@@ -172,6 +172,9 @@ export const deserializeIlpPrepare = (binary: Buffer): IlpPrepare => {
   const expiresAt = interledgerTimeToDate(reader.read(INTERLEDGER_TIME_LENGTH).toString('ascii'))
   const executionCondition = reader.read(32)
   const destination = reader.readVarOctetString().toString('ascii')
+  if (!isValidIlpAddress(destination)) {
+    throw new Error('Packet has invalid destination address')
+  }
   const data = reader.readVarOctetString()
 
   return {


### PR DESCRIPTION
Valid ILP prepares must have valid destination addresses.

Also add tests for `isValidIlpAddress`. Most test cases are imported from rust's ilp-packet implementation.