### PR TITLE
Revert "chore(ilp-plugin-btp): drop version to 1.6.0"

### DIFF
--- a/packages/ilp-plugin-btp/package.json
+++ b/packages/ilp-plugin-btp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ilp-plugin-btp",
-  "version": "1.6.0",
+  "version": "2.0.0",
   "description": "Generic BTP plugin for ILP",
   "main": "index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
This reverts commit e8320064e88ab38b84dc2660a5f80c524284ad58.

Node engines change introduction warrants a semver bump as somebody /may/ be
using this package with an old version of node.