### PR TITLE
fix: send additional data on retries

### DIFF
--- a/packages/pay/package.json
+++ b/packages/pay/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@interledger/pay",
   "description": "Send payments over Interledger",
-  "version": "0.4.0-alpha.10",
+  "version": "0.4.0-alpha.11",
   "author": "Interledger Team <info@interledger.org>",
   "license": "Apache-2.0",
   "publishConfig": {

--- a/packages/pay/src/controllers/app.ts
+++ b/packages/pay/src/controllers/app.ts
@@ -1,12 +1,12 @@
 import { RequestState, StreamController } from '.'
-import { RequestBuilder } from '../request'
+import { RequestBuilder, StreamReply, StreamRequest } from '../request'
 import { StreamDataFrame } from 'ilp-protocol-stream/dist/src/packet'
 
 // Injects application data on the first STREAM packet
 export class AppController implements StreamController {
   private readonly appData?: Buffer
   private readonly streamId: number
-  private hasInjected = false
+  private isDelivered = false
 
   constructor(appData?: Uint8Array | string | Buffer, streamId = 1) {
     this.streamId = streamId
@@ -16,13 +16,24 @@ export class AppController implements StreamController {
   }
 
   buildRequest(request: RequestBuilder): RequestState {
-    if (!this.appData || this.hasInjected) {
+    if (!this.appData || this.isDelivered) {
       return RequestState.Ready()
     }
 
     request.addFrames(new StreamDataFrame(this.streamId, 0, this.appData))
-    this.hasInjected = true
 
     return RequestState.Ready()
+  }
+
+  applyRequest(_request: StreamRequest): ((reply: StreamReply) => void) | undefined {
+    if (!this.appData || this.isDelivered) {
+      return
+    }
+
+    return (reply: StreamReply) => {
+      if (reply.isAuthentic()) {
+        this.isDelivered = true
+      }
+    }
   }
 }

--- a/packages/pay/test/payment.spec.ts
+++ b/packages/pay/test/payment.spec.ts
@@ -1872,6 +1872,68 @@ describe('application data handling', () => {
     expect(appDataPackets).toBe(1)
   })
 
+  it('retries app data on a temporary reject of the first packet', async () => {
+    const { sharedSecret, ilpAddress: destinationAddress } = streamServer.generateCredentials()
+    const encryptionKey = generateEncryptionKey(sharedSecret)
+    const defaultStreamId = Long.fromNumber(PaymentSender.DEFAULT_STREAM_ID, true)
+
+    let appDataPackets = 0
+    let rejectedFirstAppDataPacket = false
+    const plugin = createPlugin(async (prepare, next) => {
+      const streamPacket = await Packet.decryptAndDeserialize(encryptionKey, prepare.data)
+      const frames = streamPacket.frames ?? []
+      const hasAppData = frames.some(
+        (frame) => frame.type === FrameType.StreamData && frame.streamId.equals(defaultStreamId)
+      )
+
+      if (hasAppData) {
+        appDataPackets++
+        if (!rejectedFirstAppDataPacket) {
+          rejectedFirstAppDataPacket = true
+          return {
+            code: IlpError.T00_INTERNAL_ERROR,
+            message: 'temporary failure',
+            triggeredBy: '',
+            data: Buffer.alloc(0),
+          }
+        }
+      }
+
+      return next(prepare)
+    }, streamReceiver)
+
+    const destination = await setupPayment({
+      plugin,
+      destinationAddress,
+      sharedSecret,
+      destinationAsset: {
+        code: 'USD',
+        scale: 2,
+      },
+    })
+    const quote = await startQuote({
+      plugin,
+      destination,
+      amountToDeliver: 100,
+      sourceAsset: {
+        code: 'USD',
+        scale: 2,
+      },
+      slippage: 0.01,
+    })
+
+    const receipt = await pay({
+      plugin,
+      destination,
+      quote,
+      appData: Buffer.from('data-from-sender'),
+    })
+
+    expect(receipt.error).toBeUndefined()
+    expect(rejectedFirstAppDataPacket).toBe(true)
+    expect(appDataPackets).toBe(2)
+  })
+
   it('does not attribute later rejects to the initial app data packet', async () => {
     const { sharedSecret, ilpAddress: destinationAddress } = streamServer.generateCredentials()
     const encryptionKey = generateEncryptionKey(sharedSecret)


### PR DESCRIPTION
## Changes

This PR updates the `AppController` such that app data is always sent when packets are retried. Previously, app data was only sent on the first try.